### PR TITLE
Do not print exception

### DIFF
--- a/src/com/enea/jcarder/agent/StaticEventListener.java
+++ b/src/com/enea/jcarder/agent/StaticEventListener.java
@@ -20,6 +20,8 @@ import net.jcip.annotations.ThreadSafe;
 import com.enea.jcarder.common.LockingContext;
 import com.enea.jcarder.common.events.LockEventListenerIfc.LockEventType;
 
+import java.nio.channels.ClosedByInterruptException;
+
 /**
  * This class provides static methods that are supposed to be invoked directly
  * from the instrumented classes.
@@ -82,6 +84,8 @@ public final class StaticEventListener {
                                      monitor,
                                      lockingContext);
             }
+        } catch (ClosedByInterruptException e) {
+            // nothing to do because we cannot do anything
         } catch (Throwable t) {
             handleError(t);
         }


### PR DESCRIPTION
java.nio.channels.ClosedByInterruptException
            at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
            at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:200)
            at com.enea.jcarder.common.contexts.ContextFileWriter.writeBuffer(ContextFileWriter.java:80)
            at com.enea.jcarder.common.contexts.ContextFileWriter.assureBufferCapacity(ContextFileWriter.java:117)
            at com.enea.jcarder.common.contexts.ContextFileWriter.writeString(ContextFileWriter.java:103)
            at com.enea.jcarder.common.contexts.ContextFileWriter.writeContext(ContextFileWriter.java:139)
            at com.enea.jcarder.agent.LockingContextIdCache.acquireContextId(LockingContextIdCache.java:80)
            at com.enea.jcarder.agent.EventListener.lockEvent(EventListener.java:198)
            at com.enea.jcarder.agent.EventListener.handleEvent(EventListener.java:110)
            at com.enea.jcarder.agent.StaticEventListener.handleEvent(StaticEventListener.java:81)
