### PR TITLE
optimization: add "lock transition" entity

### DIFF
--- a/src/com/enea/jcarder/analyzer/Cycle.java
+++ b/src/com/enea/jcarder/analyzer/Cycle.java
@@ -16,11 +16,7 @@
 
 package com.enea.jcarder.analyzer;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.*;
 
 import com.enea.jcarder.common.contexts.ContextReaderIfc;
 
@@ -73,9 +69,12 @@ class Cycle {
         // TODO Cache the result to improve performance?
         final Iterator<LockEdge> iter = mEdgesInCycle.iterator();
         if (iter.hasNext()) {
-            final long firstThreadId = iter.next().getThreadId();
+            final long firstThreadId = iter.next().getUniqueThreadId();
+            if (firstThreadId < 0) {
+                return false;
+            }
             while (iter.hasNext()) {
-                if (firstThreadId != iter.next().getThreadId()) {
+                if (!iter.next().hasUniqueThreadId(firstThreadId)) {
                     return false;
                 }
             }
@@ -89,7 +88,7 @@ class Cycle {
 
         while (iter.hasNext()) {
             LockEdge edge = iter.next();
-            for (int gateLockId : edge.getGateLockIds()) {
+            for (int gateLockId : edge.getCommonGateLockIds()) {
                 // shared locks dont gate
                 if (gateLockId < 0) continue;
 
@@ -117,6 +116,12 @@ class Cycle {
         return false;
     }
 
+    void removeAlikeTransitions(ContextReaderIfc reader) {
+        for (LockEdge edge : mEdgesInCycle) {
+            edge.removeAlikeTransitions(reader);
+        }
+    }
+
     boolean alike(Cycle other, ContextReaderIfc reader) {
         if (this.equals(other)) {
             return true;
@@ -142,6 +147,14 @@ class Cycle {
             return false;
         }
         return true;
+    }
+
+    int getNumberOfTransitionCycles() {
+        int transitionCycles = 1;
+        for (LockEdge edge : mEdgesInCycle) {
+            transitionCycles *= edge.getTransitions().size();
+        }
+        return transitionCycles;
     }
 
     public boolean equals(Object obj) {

--- a/src/com/enea/jcarder/analyzer/Cycle.java
+++ b/src/com/enea/jcarder/analyzer/Cycle.java
@@ -69,12 +69,12 @@ class Cycle {
         // TODO Cache the result to improve performance?
         final Iterator<LockEdge> iter = mEdgesInCycle.iterator();
         if (iter.hasNext()) {
-            final long firstThreadId = iter.next().getUniqueThreadId();
+            final long firstThreadId = iter.next().getThreadId();
             if (firstThreadId < 0) {
                 return false;
             }
             while (iter.hasNext()) {
-                if (!iter.next().hasUniqueThreadId(firstThreadId)) {
+                if (!iter.next().hasThreadId(firstThreadId)) {
                     return false;
                 }
             }
@@ -88,7 +88,7 @@ class Cycle {
 
         while (iter.hasNext()) {
             LockEdge edge = iter.next();
-            for (int gateLockId : edge.getCommonGateLockIds()) {
+            for (int gateLockId : edge.getGateLockIds()) {
                 // shared locks dont gate
                 if (gateLockId < 0) continue;
 
@@ -152,7 +152,7 @@ class Cycle {
     int getNumberOfTransitionCycles() {
         int transitionCycles = 1;
         for (LockEdge edge : mEdgesInCycle) {
-            transitionCycles *= edge.getTransitions().size();
+            transitionCycles *= edge.numberOfUniqueTransitions();
         }
         return transitionCycles;
     }

--- a/src/com/enea/jcarder/analyzer/CycleDetector.java
+++ b/src/com/enea/jcarder/analyzer/CycleDetector.java
@@ -16,12 +16,7 @@
 
 package com.enea.jcarder.analyzer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import net.jcip.annotations.NotThreadSafe;
 
@@ -32,8 +27,6 @@ import com.enea.jcarder.util.logging.Logger;
 
 /**
  * This class is responsible for finding and managing cycles.
- *
- * TODO Add possibility to ignore cycles guarded by a common lock.
  *
  * TODO Add possibility to ignore cycles created by two threads that cannot
  * possibly run at the same time. Is it possible to achieve that by tracking
@@ -167,6 +160,7 @@ class CycleDetector {
         Iterator<Cycle> iter = mCycles.iterator();
         while (iter.hasNext()) {
             final Cycle cycle = iter.next();
+            cycle.removeAlikeTransitions(reader);
             if (containsAlike(cycle, uniqueCycles, reader)) {
                 iter.remove();
                 removedCycles++;
@@ -224,6 +218,14 @@ class CycleDetector {
         }
         mLogger.info("Ignoring " + removedCycles + " cycle(s) that are shareable.");
     }
+
+    int getNumberOfTransitionCycles() {
+         int transitionCycles = 0;
+         for (Cycle cycle : mCycles) {
+             transitionCycles += cycle.getNumberOfTransitionCycles();
+         }
+         return transitionCycles;
+     }
 
     /**
      * Get the total number of edges in all known cycles.

--- a/src/com/enea/jcarder/analyzer/CycleDetector.java
+++ b/src/com/enea/jcarder/analyzer/CycleDetector.java
@@ -38,13 +38,15 @@ import com.enea.jcarder.util.logging.Logger;
 class CycleDetector {
     private final HashSet<Cycle> mCycles;
     private final Logger mLogger;
+    private final boolean mFastMode;
     private final MaxValueCounter mMaxDepth;
     private final MaxValueCounter mMaxCycleDepth;
     private final MaxValueCounter mNoOfCycles;
     private final Counter mNoOfCreatedCycleObjects;
 
-    CycleDetector(Logger logger) {
+    CycleDetector(Logger logger, boolean fastMode) {
         mLogger = logger;
+        mFastMode = fastMode;
         mCycles = new HashSet<Cycle>();
         mMaxDepth = new MaxValueCounter("Graph Depth", mLogger);
         mMaxCycleDepth = new MaxValueCounter("Cycle Depth", mLogger);
@@ -160,7 +162,9 @@ class CycleDetector {
         Iterator<Cycle> iter = mCycles.iterator();
         while (iter.hasNext()) {
             final Cycle cycle = iter.next();
-            cycle.removeAlikeTransitions(reader);
+            if (mFastMode) {
+                cycle.removeAlikeTransitions(reader);
+            }
             if (containsAlike(cycle, uniqueCycles, reader)) {
                 iter.remove();
                 removedCycles++;

--- a/src/com/enea/jcarder/analyzer/GraphvizGenerator.java
+++ b/src/com/enea/jcarder/analyzer/GraphvizGenerator.java
@@ -90,30 +90,33 @@ final class GraphvizGenerator {
         sb.append("  node [shape=ellipse, style=filled, fontsize=12];\n");
         final HashSet<LockNode> alreadyAppendedNodes = new HashSet<LockNode>();
         for (LockEdge edge : edgesToBePrinted) {
-            appendNodeIfNotAppended(reader,
-                                    sb,
-                                    alreadyAppendedNodes,
-                                    edge.getSource());
-            appendNodeIfNotAppended(reader,
-                                    sb,
-                                    alreadyAppendedNodes,
-                                    edge.getTarget());
-            sb.append("  " + edge.getSource().toString() + "");
-            sb.append(" -> " + edge.getTarget().toString() + "");
-            sb.append(createEdgeLabel(reader, edge, includePackages));
-            sb.append(";\n");
+            for (LockTransition transition : edge.getTransitions()) {
+                appendNodeIfNotAppended(reader,
+                        sb,
+                        alreadyAppendedNodes,
+                        edge.getSource());
+                appendNodeIfNotAppended(reader,
+                        sb,
+                        alreadyAppendedNodes,
+                        edge.getTarget());
+                sb.append("  ").append(edge.getSource().toString());
+                sb.append(" -> ").append(edge.getTarget().toString());
+
+                sb.append(createTransitionLabel(reader, transition, includePackages));
+                sb.append(";\n");
+            }
         }
         sb.append("}\n");
         return sb.toString();
     }
 
-    private String createEdgeLabel(ContextReaderIfc reader,
-                                   LockEdge edge,
-                                   boolean includePackages) {
+    private String createTransitionLabel(ContextReaderIfc reader,
+                                         LockTransition transition,
+                                         boolean includePackages) {
         final LockingContext source =
-            reader.readContext(edge.getSourceLockingContextId());
+            reader.readContext(transition.getSourceLockingContextId());
         final LockingContext target =
-            reader.readContext(edge.getTargetLockingContextId());
+            reader.readContext(transition.getTargetLockingContextId());
         return String.format(EDGE_LABEL_FORMAT,
                              escape(handlePackage(target.getThreadName(),
                                                   includePackages)),

--- a/src/com/enea/jcarder/analyzer/GraphvizGenerator.java
+++ b/src/com/enea/jcarder/analyzer/GraphvizGenerator.java
@@ -90,15 +90,17 @@ final class GraphvizGenerator {
         sb.append("  node [shape=ellipse, style=filled, fontsize=12];\n");
         final HashSet<LockNode> alreadyAppendedNodes = new HashSet<LockNode>();
         for (LockEdge edge : edgesToBePrinted) {
+
+            appendNodeIfNotAppended(reader,
+                    sb,
+                    alreadyAppendedNodes,
+                    edge.getSource());
+            appendNodeIfNotAppended(reader,
+                    sb,
+                    alreadyAppendedNodes,
+                    edge.getTarget());
+
             for (LockTransition transition : edge.getTransitions()) {
-                appendNodeIfNotAppended(reader,
-                        sb,
-                        alreadyAppendedNodes,
-                        edge.getSource());
-                appendNodeIfNotAppended(reader,
-                        sb,
-                        alreadyAppendedNodes,
-                        edge.getTarget());
                 sb.append("  ").append(edge.getSource().toString());
                 sb.append(" -> ").append(edge.getTarget().toString());
 

--- a/src/com/enea/jcarder/analyzer/LockEdge.java
+++ b/src/com/enea/jcarder/analyzer/LockEdge.java
@@ -25,109 +25,56 @@ import com.enea.jcarder.common.contexts.ContextReaderIfc;
 /**
  * A LockEdge instance represents a directed edge from a source LockNode to a
  * target LockNode.
- * Could contain several transitions
  */
 @NotThreadSafe
 class LockEdge {
     private final LockNode mSource;
     private final LockNode mTarget;
-    private Map<LockTransition, LockTransition> mTransitions;
+    private final LockTransition mTransition;
 
-    LockEdge(LockNode source, LockNode target) {
+    // full mode constructor
+    LockEdge(LockNode source, LockNode target, LockTransition transition) {
         mSource = source;
         mTarget = target;
-        mTransitions = new HashMap<>();
-    }
-
-    void addTransition(LockTransition newTransition) {
-        LockTransition existingTransition = mTransitions.get(newTransition);
-        if (existingTransition == null) {
-            mTransitions.put(newTransition, newTransition);
-        } else {
-            existingTransition.merge(newTransition);
-        }
+        mTransition = transition;
     }
 
     Collection<LockTransition> getTransitions() {
-        return mTransitions.values();
+        return Collections.singletonList(mTransition);
     }
 
+    void merge(LockEdge other) {
+        assert this.equals(other);
+        mTransition.merge(other.mTransition);
+    }
+
+
     long numberOfUniqueTransitions() {
-        return mTransitions.size();
+        return 1;
     }
 
     long numberOfDuplicatedTransitions() {
-        long numberOfDuplicatedEdges = 0;
-        for (LockTransition transition : mTransitions.values()) {
-            numberOfDuplicatedEdges += transition.getDuplicates();
-        }
-        return numberOfDuplicatedEdges;
+        return mTransition.getDuplicates();
     }
 
     void populateContextIdTranslationMap(Map<Integer, Integer> translationMap) {
-        for (LockTransition transition : mTransitions.values()) {
-            translationMap.put(transition.getSourceLockingContextId(),
-                               transition.getSourceLockingContextId());
-            translationMap.put(transition.getTargetLockingContextId(),
-                               transition.getTargetLockingContextId());
-        }
+        translationMap.put(mTransition.getSourceLockingContextId(),
+                mTransition.getSourceLockingContextId());
+        translationMap.put(mTransition.getTargetLockingContextId(),
+                mTransition.getTargetLockingContextId());
     }
 
     void translateContextIds(Map<Integer, Integer> translation) {
-        Map<LockTransition, LockTransition> oldTransitions = mTransitions;
-        mTransitions = new HashMap<>(oldTransitions.size());
-        for (LockTransition edge : oldTransitions.values()) {
-            edge.translateContextIds(translation);
-            addTransition(edge);
-        }
+        mTransition.translateContextIds(translation);
     }
 
     void removeAlikeTransitions(ContextReaderIfc reader) {
-        if (mTransitions.size() > 1) {
-            Collection<LockTransition> uniqueTransitions = new ArrayList<>();
-            Iterator<LockTransition> iter = mTransitions.values().iterator();
-            while (iter.hasNext()) {
-                final LockTransition transition = iter.next();
-                if (containsAlike(transition, uniqueTransitions, reader)) {
-                    iter.remove();
-                } else {
-                    uniqueTransitions.add(transition);
-                }
-            }
-        }
-    }
-
-    private boolean containsAlike(LockTransition transition, Collection<LockTransition> others, ContextReaderIfc reader) {
-        for (LockTransition other : others) {
-            if (transition.alike(other, reader)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     boolean alike(LockEdge other, ContextReaderIfc reader) {
-        if (!mSource.alike(other.mSource, reader)
-                || !mTarget.alike(other.mTarget, reader)
-                || mTransitions.size() != other.mTransitions.size()) {
-            return false;
-        }
-
-        // TODO Refactor the following code?
-        LinkedList<LockTransition> otherTransitions =
-            new LinkedList<>(other.mTransitions.values());
-        outerLoop:
-        for (LockTransition transition : mTransitions.values()) {
-            Iterator<LockTransition> iter = otherTransitions.iterator();
-            while (iter.hasNext()) {
-                if (transition.alike(iter.next(), reader)) {
-                    iter.remove();
-                    continue outerLoop;
-                }
-            }
-            return false;
-        }
-        return true;
+        return mSource.alike(other.mSource, reader)
+                && mTarget.alike(other.mTarget, reader)
+                && mTransition.alike(other.mTransition, reader);
     }
 
     public boolean equals(Object obj) {
@@ -139,7 +86,7 @@ class LockEdge {
             LockEdge other = (LockEdge) obj;
             return (mTarget.getLockId() == other.mTarget.getLockId())
             && (mSource.getLockId() == other.mSource.getLockId())
-//            && (mTransitions.equals(other.mTransitions))
+            && (mTransition.equals(other.mTransition))
             ;
         } catch (Exception e) {
             return false;
@@ -150,8 +97,7 @@ class LockEdge {
         final int prime = 31;
         int result = prime + mSource.getLockId();
         result = prime * result + mTarget.getLockId();
-//        for (LockTransition transition : mTransitions.values())
-//            result = prime * result + transition.hashCode();
+        result = prime * result + mTransition.hashCode();
         return result;
     }
 
@@ -163,45 +109,19 @@ class LockEdge {
         return mSource;
     }
 
-    long getUniqueThreadId() {
-        long uniqueThreadId = -1;
-        for (LockTransition transition : mTransitions.values()) {
-            long transitionThreadId = transition.getThreadId();
-            if (uniqueThreadId == -1) {
-                uniqueThreadId = transitionThreadId;
-            } else if (uniqueThreadId != transitionThreadId) {
-                return -1;
-            }
-        }
-        return uniqueThreadId;
+    long getThreadId() {
+        return mTransition.getThreadId();
     }
 
-    boolean hasUniqueThreadId(long threadId) {
-        for (LockTransition transition : mTransitions.values()) {
-            if (transition.getThreadId() != threadId) {
-                return false;
-            }
-        }
-        return true;
+    boolean hasThreadId(long threadId) {
+        return mTransition.getThreadId() == threadId;
     }
 
-    Set<Integer> getCommonGateLockIds() {
-        Set<Integer> commonGateLockIds;
-        Iterator<LockTransition> iter = mTransitions.values().iterator();
-        LockTransition firstTransition = iter.next();
-        // optimization for single transition
-        if (iter.hasNext()) {
-            commonGateLockIds = new HashSet<>(firstTransition.getGateLockIds());
-            while (iter.hasNext()) {
-                commonGateLockIds.retainAll(iter.next().getGateLockIds());
-            }
-        } else {
-            commonGateLockIds = firstTransition.getGateLockIds();
-        }
-        return commonGateLockIds;
+    Set<Integer> getGateLockIds() {
+        return mTransition.getGateLockIds();
     }
 
     public String toString() {
-        return "  " + mSource + "->" + mTarget;
+        return "  " + mSource + "->" + mTarget + "(t " + mTransition.getThreadId() + ")";
     }
 }

--- a/src/com/enea/jcarder/analyzer/LockGraphBuilder.java
+++ b/src/com/enea/jcarder/analyzer/LockGraphBuilder.java
@@ -19,12 +19,10 @@ package com.enea.jcarder.analyzer;
 import com.enea.jcarder.common.contexts.ContextReaderIfc;
 import com.enea.jcarder.util.logging.Logger;
 import java.util.HashMap;
-import java.util.Stack;
 
 import net.jcip.annotations.NotThreadSafe;
 
 import com.enea.jcarder.common.events.LockEventListenerIfc;
-import com.enea.jcarder.common.events.LockEventListenerIfc.LockEventType;
 
 /**
  * This class is responsible for constructing a structure of LockNode and
@@ -108,13 +106,15 @@ class LockGraphBuilder implements LockEventListenerIfc {
             // locks to this one.
             for (LockWithContext sourceLwc : heldLocks.values()) {
                 LockNode sourceLock = getLockNode(sourceLwc.nodeId);
-                final LockEdge edge = new LockEdge(sourceLock,
-                                                   targetLock,
-                                                   threadId,
-                                                   sourceLwc.contextId,
-                                                   lockingContextId,
-                                                   heldLocks.keySet());
-                sourceLock.addOutgoingEdge(edge);
+                final LockEdge edge = new LockEdge(sourceLock, targetLock);
+                final LockTransition transition = new LockTransition(
+                        threadId,
+                        sourceLwc.contextId,
+                        lockingContextId,
+                        heldLocks.keySet()
+                );
+                sourceLock.addOutgoingEdge(edge)
+                        .addTransition(transition);
             }
 
             // And add this one to the set.

--- a/src/com/enea/jcarder/analyzer/LockMultiEdge.java
+++ b/src/com/enea/jcarder/analyzer/LockMultiEdge.java
@@ -1,0 +1,182 @@
+package com.enea.jcarder.analyzer;
+
+import com.enea.jcarder.common.contexts.ContextReaderIfc;
+
+import java.util.*;
+
+/**
+ * Same as {@link LockEdge} but could contain several transitions
+ */
+public class LockMultiEdge extends LockEdge {
+    private Map<LockTransition, LockTransition> mTransitions;
+
+    LockMultiEdge(LockNode source, LockNode target) {
+        super(source, target, null);
+        mTransitions = new HashMap<>();
+    }
+
+    void addTransition(LockTransition newTransition) {
+        LockTransition existingTransition = mTransitions.get(newTransition);
+        if (existingTransition == null) {
+            mTransitions.put(newTransition, newTransition);
+        } else {
+            existingTransition.merge(newTransition);
+        }
+    }
+
+    Collection<LockTransition> getTransitions() {
+        return mTransitions.values();
+    }
+
+    @Override
+    void merge(LockEdge other) {
+        // multi-edges cannot merge
+    }
+
+    long numberOfUniqueTransitions() {
+        return mTransitions.size();
+    }
+
+    long numberOfDuplicatedTransitions() {
+        long numberOfDuplicatedEdges = 0;
+        for (LockTransition transition : mTransitions.values()) {
+            numberOfDuplicatedEdges += transition.getDuplicates();
+        }
+        return numberOfDuplicatedEdges;
+    }
+
+    void populateContextIdTranslationMap(Map<Integer, Integer> translationMap) {
+        for (LockTransition transition : mTransitions.values()) {
+            translationMap.put(transition.getSourceLockingContextId(),
+                               transition.getSourceLockingContextId());
+            translationMap.put(transition.getTargetLockingContextId(),
+                               transition.getTargetLockingContextId());
+        }
+    }
+
+    void translateContextIds(Map<Integer, Integer> translation) {
+        Map<LockTransition, LockTransition> oldTransitions = mTransitions;
+        mTransitions = new HashMap<>(oldTransitions.size());
+        for (LockTransition edge : oldTransitions.values()) {
+            edge.translateContextIds(translation);
+            addTransition(edge);
+        }
+    }
+
+    void removeAlikeTransitions(ContextReaderIfc reader) {
+        if (mTransitions.size() > 1) {
+            Collection<LockTransition> uniqueTransitions = new ArrayList<>();
+            Iterator<LockTransition> iter = mTransitions.values().iterator();
+            while (iter.hasNext()) {
+                final LockTransition transition = iter.next();
+                if (containsAlike(transition, uniqueTransitions, reader)) {
+                    iter.remove();
+                } else {
+                    uniqueTransitions.add(transition);
+                }
+            }
+        }
+    }
+
+    private boolean containsAlike(LockTransition transition, Collection<LockTransition> others, ContextReaderIfc reader) {
+        for (LockTransition other : others) {
+            if (transition.alike(other, reader)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    boolean alike(LockEdge otherEdge, ContextReaderIfc reader) {
+        LockMultiEdge other = (LockMultiEdge) otherEdge;
+        if (!getSource().alike(other.getSource(), reader)
+                || !getTarget().alike(other.getTarget(), reader)
+                || mTransitions.size() != other.mTransitions.size()) {
+            return false;
+        }
+
+        // TODO Refactor the following code?
+        LinkedList<LockTransition> otherTransitions =
+            new LinkedList<>(other.mTransitions.values());
+        outerLoop:
+        for (LockTransition transition : mTransitions.values()) {
+            Iterator<LockTransition> iter = otherTransitions.iterator();
+            while (iter.hasNext()) {
+                if (transition.alike(iter.next(), reader)) {
+                    iter.remove();
+                    continue outerLoop;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    public boolean equals(Object obj) {
+        /*
+         * TODO It might be a potential problem to use LockEdges in HashMaps
+         * since they are mutable and this equals method depends on them?
+         */
+        try {
+            LockEdge other = (LockEdge) obj;
+            return (getTarget().getLockId() == other.getTarget().getLockId())
+            && (getSource().getLockId() == other.getSource().getLockId())
+//            && (mTransitions.equals(other.mTransitions))
+            ;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = prime + getSource().getLockId();
+        result = prime * result + getTarget().getLockId();
+//        for (LockTransition transition : mTransitions.values())
+//            result = prime * result + transition.hashCode();
+        return result;
+    }
+
+    long getThreadId() {
+        long uniqueThreadId = -1;
+        for (LockTransition transition : mTransitions.values()) {
+            long transitionThreadId = transition.getThreadId();
+            if (uniqueThreadId == -1) {
+                uniqueThreadId = transitionThreadId;
+            } else if (uniqueThreadId != transitionThreadId) {
+                return -1;
+            }
+        }
+        return uniqueThreadId;
+    }
+
+    boolean hasThreadId(long threadId) {
+        for (LockTransition transition : mTransitions.values()) {
+            if (transition.getThreadId() != threadId) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    Set<Integer> getGateLockIds() {
+        Set<Integer> commonGateLockIds;
+        Iterator<LockTransition> iter = mTransitions.values().iterator();
+        LockTransition firstTransition = iter.next();
+        // optimization for single transition
+        if (iter.hasNext()) {
+            commonGateLockIds = new HashSet<>(firstTransition.getGateLockIds());
+            while (iter.hasNext()) {
+                commonGateLockIds.retainAll(iter.next().getGateLockIds());
+            }
+        } else {
+            commonGateLockIds = firstTransition.getGateLockIds();
+        }
+        return commonGateLockIds;
+    }
+
+    public String toString() {
+        return "  " + getSource() + "->" + getTarget();
+    }
+}

--- a/src/com/enea/jcarder/analyzer/LockNode.java
+++ b/src/com/enea/jcarder/analyzer/LockNode.java
@@ -57,6 +57,7 @@ class LockNode {
     LockEdge addOutgoingEdge(LockEdge newEdge) {
         LockEdge existingEdge = mOutgoingEdges.get(newEdge);
         if (existingEdge != null) {
+            existingEdge.merge(newEdge);
             return existingEdge;
         }
         mOutgoingEdges.put(newEdge, newEdge);

--- a/src/com/enea/jcarder/analyzer/LockNode.java
+++ b/src/com/enea/jcarder/analyzer/LockNode.java
@@ -54,21 +54,18 @@ class LockNode {
         }
     }
 
-    void addOutgoingEdge(LockEdge newEdge) {
+    LockEdge addOutgoingEdge(LockEdge newEdge) {
         LockEdge existingEdge = mOutgoingEdges.get(newEdge);
-        if (existingEdge == null) {
-            mOutgoingEdges.put(newEdge, newEdge);
-        } else {
-            existingEdge.merge(newEdge);
+        if (existingEdge != null) {
+            return existingEdge;
         }
+        mOutgoingEdges.put(newEdge, newEdge);
+        return newEdge;
     }
 
     void populateContextIdTranslationMap(Map<Integer, Integer> translationMap) {
         for (LockEdge edge : mOutgoingEdges.values()) {
-            translationMap.put(edge.getSourceLockingContextId(),
-                               edge.getSourceLockingContextId());
-            translationMap.put(edge.getTargetLockingContextId(),
-                               edge.getTargetLockingContextId());
+            edge.populateContextIdTranslationMap(translationMap);
         }
     }
 
@@ -93,16 +90,20 @@ class LockNode {
         }
     }
 
-    long numberOfUniqueEdges() {
-        return mOutgoingEdges.size();
+    long numberOfUniqueTransitions() {
+        long numberOfUniqueTransitions = 0;
+        for (LockEdge edge : mOutgoingEdges.values()) {
+            numberOfUniqueTransitions += edge.numberOfUniqueTransitions();
+        }
+        return numberOfUniqueTransitions;
     }
 
-    long numberOfDuplicatedEdges() {
-        long numberOfDuplicatedEdges = 0;
+    long numberOfDuplicatedTransitions() {
+        long numberOfDuplicatedTransitions = 0;
         for (LockEdge edge : mOutgoingEdges.values()) {
-            numberOfDuplicatedEdges += edge.getDuplicates();
+            numberOfDuplicatedTransitions += edge.numberOfDuplicatedTransitions();
         }
-        return numberOfDuplicatedEdges;
+        return numberOfDuplicatedTransitions;
     }
 
     boolean alike(LockNode other, ContextReaderIfc reader) {

--- a/src/com/enea/jcarder/analyzer/LockTransition.java
+++ b/src/com/enea/jcarder/analyzer/LockTransition.java
@@ -1,0 +1,118 @@
+package com.enea.jcarder.analyzer;
+
+import com.enea.jcarder.common.LockingContext;
+import com.enea.jcarder.common.contexts.ContextReaderIfc;
+import net.jcip.annotations.NotThreadSafe;
+
+import java.util.*;
+
+/**
+ * A lock transition represents transition from source lock to target
+ */
+@NotThreadSafe
+class LockTransition {
+    private final long mThreadId; // The thread that did the synchronization.
+    private int mSourceContextId;
+    private int mTargetContextId;
+    private long mNumberOfDuplicates;
+
+    private Set<Integer> mGateLockIds;
+
+    LockTransition(long threadId,
+             int sourceLockingContextId,
+             int targetLockingContextId) {
+        this(threadId, sourceLockingContextId, targetLockingContextId,
+             Collections.emptyList());
+    }
+
+    LockTransition(long threadId,
+             int sourceLockingContextId,
+             int targetLockingContextId,
+             Collection<Integer> gateLockIds) {
+        mThreadId = threadId;
+        mSourceContextId = sourceLockingContextId;
+        mTargetContextId = targetLockingContextId;
+        mNumberOfDuplicates = 0;
+        mGateLockIds = new HashSet<>(gateLockIds);
+    }
+
+    void merge(LockTransition other) {
+        assert this.equals(other);
+        mNumberOfDuplicates += (other.mNumberOfDuplicates + 1);
+    }
+
+    long getDuplicates() {
+        return mNumberOfDuplicates;
+    }
+
+    boolean alike(LockTransition other, ContextReaderIfc reader) {
+        /*
+         * TODO Some kind of cache to improve performance? Note that the context
+         * IDs are not declared final.
+         */
+        LockingContext thisSourceContext =
+            reader.readContext(mSourceContextId);
+        LockingContext otherSourceContext =
+            reader.readContext(other.mSourceContextId);
+        LockingContext thisTargetContext =
+            reader.readContext(mTargetContextId);
+        LockingContext otherTargetContext =
+            reader.readContext(other.mTargetContextId);
+        return thisSourceContext.alike(otherSourceContext)
+               && thisTargetContext.alike(otherTargetContext);
+    }
+
+    public boolean equals(Object obj) {
+        try {
+            LockTransition other = (LockTransition) obj;
+            return (mThreadId == other.mThreadId)
+            && (mSourceContextId == other.mSourceContextId)
+            && (mTargetContextId == other.mTargetContextId);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = prime * mSourceContextId;
+        result = prime * result + mTargetContextId;
+        result = prime * result + (int) (mThreadId ^ (mThreadId >>> 32));
+        return result;
+    }
+
+    int getSourceLockingContextId() {
+        return mSourceContextId;
+    }
+
+    int getTargetLockingContextId() {
+        return mTargetContextId;
+    }
+
+    /**
+     * Translate the source and target context ID according to a translation
+     * map.
+     */
+    void translateContextIds(Map<Integer, Integer> translation) {
+        final Integer newSourceId = translation.get(mSourceContextId);
+        if (newSourceId != null && newSourceId != mSourceContextId) {
+            mSourceContextId = newSourceId;
+        }
+        final Integer newTargetId = translation.get(mTargetContextId);
+        if (newTargetId != null && newSourceId != mTargetContextId) {
+            mTargetContextId = newTargetId;
+        }
+    }
+
+    long getThreadId() {
+        return mThreadId;
+    }
+
+    Set<Integer> getGateLockIds() {
+        return mGateLockIds;
+    }
+
+    public String toString() {
+        return "(t " + mThreadId + ")";
+    }
+}

--- a/test/com/enea/jcarder/analyzer/TestCycleDetector.java
+++ b/test/com/enea/jcarder/analyzer/TestCycleDetector.java
@@ -33,160 +33,138 @@ public final class TestCycleDetector {
     LockGraphBuilder mBuilder;
     CycleDetector mCycleDetector;
     LinkedList<LockNode> mNodes;
-    Set<Set<LockTransition>> mExpectedCycles;
+    HashSet<Cycle> mExpectedCycles;
 
     @Before
     public void setUp() {
-        mBuilder = new LockGraphBuilder(new Logger(null), null);
-        mCycleDetector = new CycleDetector(new Logger(null));
-        mNodes = new LinkedList<>();
-        mExpectedCycles = new HashSet<>();
+        mBuilder = new LockGraphBuilder(new Logger(null), false, null);
+        mCycleDetector = new CycleDetector(new Logger(null), false);
+        mNodes = new LinkedList<LockNode>();
+        mExpectedCycles = new HashSet<Cycle>();
     }
 
-    private LockTransition addTransition(int from, int to) {
-        return addTransition(from, to, -1);
+    private LockEdge addEdge(int from, int to) {
+        return addEdge(from, to, -1);
     }
 
-    private LockTransition addTransition(int from, int to, int threadId) {
+    private LockEdge addEdge(int from, int to, int threadId) {
         final LockNode sourceLock = mBuilder.getLockNode(from);
         final LockNode targetLock = mBuilder.getLockNode(to);
-        final LockEdge edge = new LockEdge(sourceLock, targetLock);
-        LockTransition transition = new LockTransition(threadId, -1, -1);
-        sourceLock.addOutgoingEdge(edge)
-                .addTransition(transition);
+        final LockEdge edge = new LockEdge(sourceLock,
+                                           targetLock,
+                                           new LockTransition(threadId, -1, -1));
+        sourceLock.addOutgoingEdge(edge);
         if (!mNodes.contains(sourceLock)) {
             mNodes.add(sourceLock);
         }
         if (!mNodes.contains(sourceLock)) {
             mNodes.add(sourceLock);
         }
-        return transition;
+        return edge;
     }
 
-    private void addExpectedCycle(LockTransition[] transitions) {
-        Set<LockTransition> set = Collections.newSetFromMap(new IdentityHashMap<>());
-        set.addAll(Arrays.asList(transitions));
-        mExpectedCycles.add(set);
+    private void addExpectedCycle(LockEdge[] edges) {
+        Cycle cycle = new Cycle(Arrays.asList(edges));
+        mExpectedCycles.add(cycle);
     }
 
     private void assertExpectedCycles() {
-        Assert.assertEquals(mExpectedCycles, getTransitionCycles(mCycleDetector.getCycles()));
-    }
-
-    private Set<Set> getTransitionCycles(HashSet<Cycle> cycles) {
-        Set<Set> transitionCycles = new HashSet<>();
-        for (Cycle cycle : cycles) {
-            addAllTransitionCycles(new ArrayList<>(cycle.getEdges()), transitionCycles, new LockTransition[cycle.getEdges().size()], 0);
-        }
-        return transitionCycles;
-    }
-
-    private void addAllTransitionCycles(List<LockEdge> edges, Collection<Set> cycles, LockTransition[] transitionsContainer, int start) {
-        if (start == edges.size()) {
-            Set<LockTransition> set = Collections.newSetFromMap(new IdentityHashMap<>());
-            set.addAll(Arrays.asList(transitionsContainer));
-            cycles.add(set);
-            return;
-        }
-        for (LockTransition transition : edges.get(start).getTransitions()) {
-            transitionsContainer[start] = transition;
-            addAllTransitionCycles(edges, cycles, transitionsContainer, start + 1);
-        }
+        Assert.assertEquals(mExpectedCycles, mCycleDetector.getCycles());
     }
 
     @Test
     public void testNoCycle() {
-        addTransition(1, 2);
-        addTransition(2, 3);
-        addTransition(1, 3);
-        addTransition(3, 4);
+        addEdge(1, 2);
+        addEdge(2, 3);
+        addEdge(1, 3);
+        addEdge(3, 4);
         mCycleDetector.analyzeLockNodes(mNodes);
         assertExpectedCycles();
     }
 
     @Test
     public void testSmallCycle() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 1);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 1);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockEdge[] {e1, e2});
         assertExpectedCycles();
     }
 
     @Test
     public void testCycle() {
-        addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 3);
-        LockTransition e3 = addTransition(3, 4);
-        LockTransition e4 = addTransition(4, 2);
-        addTransition(4, 5);
+        addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 3);
+        LockEdge e3 = addEdge(3, 4);
+        LockEdge e4 = addEdge(4, 2);
+        addEdge(4, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e2, e3, e4});
+        addExpectedCycle(new LockEdge[] {e2, e3, e4});
         assertExpectedCycles();
     }
 
     @Test
     public void testCyclesWithTwoPaths() {
-        addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 3);
-        LockTransition e3 = addTransition(3, 4);
-        LockTransition e4 = addTransition(2, 4);
-        LockTransition e5 = addTransition(4, 2);
+        addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 3);
+        LockEdge e3 = addEdge(3, 4);
+        LockEdge e4 = addEdge(2, 4);
+        LockEdge e5 = addEdge(4, 2);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e2, e3, e5});
-        addExpectedCycle(new LockTransition[] {e4, e5});
+        addExpectedCycle(new LockEdge[] {e2, e3, e5});
+        addExpectedCycle(new LockEdge[] {e4, e5});
         assertExpectedCycles();
     }
 
     @Test
     public void testCyclesWithTwoTimesTwoPathsLarge() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 3);
-        LockTransition e3 = addTransition(3, 4);
-        LockTransition e3b = addTransition(3, 4, 2);
-        LockTransition e4 = addTransition(4, 5);
-        LockTransition e5 = addTransition(5, 6);
-        LockTransition e6 = addTransition(6, 1);
-        LockTransition e6b = addTransition(6, 1, 2);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 3);
+        LockEdge e3 = addEdge(3, 4);
+        LockEdge e3b = addEdge(3, 4, 2);
+        LockEdge e4 = addEdge(4, 5);
+        LockEdge e5 = addEdge(5, 6);
+        LockEdge e6 = addEdge(6, 1);
+        LockEdge e6b = addEdge(6, 1, 2);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4, e5, e6});
-        addExpectedCycle(new LockTransition[] {e1, e2, e3b, e4, e5, e6});
-        addExpectedCycle(new LockTransition[] {e1, e2, e3b, e4, e5, e6b});
-        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4, e5, e6b});
+        addExpectedCycle(new LockEdge[] {e1, e2, e3, e4, e5, e6});
+        addExpectedCycle(new LockEdge[] {e1, e2, e3b, e4, e5, e6});
+        addExpectedCycle(new LockEdge[] {e1, e2, e3b, e4, e5, e6b});
+        addExpectedCycle(new LockEdge[] {e1, e2, e3, e4, e5, e6b});
         assertExpectedCycles();
     }
 
     @Test
     public void testCyclesWithTwoTimesTwoPathsSmall() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 1);
-        LockTransition e1b = addTransition(1, 2, 2);
-        LockTransition e2b = addTransition(2, 1, 2);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 1);
+        LockEdge e1b = addEdge(1, 2, 2);
+        LockEdge e2b = addEdge(2, 1, 2);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e2});
-        addExpectedCycle(new LockTransition[] {e1b, e2});
-        addExpectedCycle(new LockTransition[] {e1, e2b});
-        addExpectedCycle(new LockTransition[] {e1b, e2b});
+        addExpectedCycle(new LockEdge[] {e1, e2});
+        addExpectedCycle(new LockEdge[] {e1b, e2});
+        addExpectedCycle(new LockEdge[] {e1, e2b});
+        addExpectedCycle(new LockEdge[] {e1b, e2b});
         assertExpectedCycles();
     }
 
 
     @Test
     public void testCyclesWithTwoAlternateWays() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(1, 3);
-        LockTransition e3 = addTransition(2, 4);
-        LockTransition e4 = addTransition(3, 4);
-        LockTransition e5 = addTransition(4, 5);
-        LockTransition e6 = addTransition(4, 6);
-        LockTransition e7 = addTransition(5, 1);
-        LockTransition e8 = addTransition(6, 1);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(1, 3);
+        LockEdge e3 = addEdge(2, 4);
+        LockEdge e4 = addEdge(3, 4);
+        LockEdge e5 = addEdge(4, 5);
+        LockEdge e6 = addEdge(4, 6);
+        LockEdge e7 = addEdge(5, 1);
+        LockEdge e8 = addEdge(6, 1);
 
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e3, e5, e7});
-        addExpectedCycle(new LockTransition[] {e1, e3, e6, e8});
-        addExpectedCycle(new LockTransition[] {e2, e4, e5, e7});
-        addExpectedCycle(new LockTransition[] {e2, e4, e6, e8});
+        addExpectedCycle(new LockEdge[] {e1, e3, e5, e7});
+        addExpectedCycle(new LockEdge[] {e1, e3, e6, e8});
+        addExpectedCycle(new LockEdge[] {e2, e4, e5, e7});
+        addExpectedCycle(new LockEdge[] {e2, e4, e6, e8});
         assertExpectedCycles();
     }
 
@@ -195,23 +173,23 @@ public final class TestCycleDetector {
     public void testComplexCycles() {
         int a = 6;
         int b = 3;
-        addTransition(1, 2);
-        LockTransition e2 = addTransition(2, b);
-        LockTransition e3 = addTransition(b, 4);
-        LockTransition e4 = addTransition(4, b);
-        LockTransition e5 = addTransition(b, 5);
-        LockTransition e6 = addTransition(5, 7);
-        LockTransition e7 = addTransition(7, 2);
-        LockTransition e8 = addTransition(2, a);
-        LockTransition e9 = addTransition(a, 5);
-        LockTransition e10 = addTransition(5, 8);
-        LockTransition e11 = addTransition(8, 9);
-        LockTransition e12 = addTransition(9, 5);
+        addEdge(1, 2);
+        LockEdge e2 = addEdge(2, b);
+        LockEdge e3 = addEdge(b, 4);
+        LockEdge e4 = addEdge(4, b);
+        LockEdge e5 = addEdge(b, 5);
+        LockEdge e6 = addEdge(5, 7);
+        LockEdge e7 = addEdge(7, 2);
+        LockEdge e8 = addEdge(2, a);
+        LockEdge e9 = addEdge(a, 5);
+        LockEdge e10 = addEdge(5, 8);
+        LockEdge e11 = addEdge(8, 9);
+        LockEdge e12 = addEdge(9, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e3, e4});
-        addExpectedCycle(new LockTransition[] {e10, e11, e12});
-        addExpectedCycle(new LockTransition[] {e8, e9, e6, e7});
-        addExpectedCycle(new LockTransition[] {e2, e5, e6, e7});
+        addExpectedCycle(new LockEdge[] {e3, e4});
+        addExpectedCycle(new LockEdge[] {e10, e11, e12});
+        addExpectedCycle(new LockEdge[] {e8, e9, e6, e7});
+        addExpectedCycle(new LockEdge[] {e2, e5, e6, e7});
         assertExpectedCycles();
     }
 
@@ -223,21 +201,21 @@ public final class TestCycleDetector {
         int c = 3;
         int d = 4;
 
-        LockTransition e1 = addTransition(a, b);
-        LockTransition e2 = addTransition(a, c);
-        LockTransition e3 = addTransition(a, d);
-        LockTransition e4 = addTransition(b, a);
-        LockTransition e5 = addTransition(b, c);
-        LockTransition e6 = addTransition(c, b);
-        LockTransition e7 = addTransition(c, d);
-        LockTransition e8 = addTransition(d, b);
+        LockEdge e1 = addEdge(a, b);
+        LockEdge e2 = addEdge(a, c);
+        LockEdge e3 = addEdge(a, d);
+        LockEdge e4 = addEdge(b, a);
+        LockEdge e5 = addEdge(b, c);
+        LockEdge e6 = addEdge(c, b);
+        LockEdge e7 = addEdge(c, d);
+        LockEdge e8 = addEdge(d, b);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e4});
-        addExpectedCycle(new LockTransition[] {e5, e6});
-        addExpectedCycle(new LockTransition[] {e2, e6, e4});
-        addExpectedCycle(new LockTransition[] {e3, e8, e4});
-        addExpectedCycle(new LockTransition[] {e5, e7, e8});
-        addExpectedCycle(new LockTransition[] {e2, e7, e8, e4});
+        addExpectedCycle(new LockEdge[] {e1, e4});
+        addExpectedCycle(new LockEdge[] {e5, e6});
+        addExpectedCycle(new LockEdge[] {e2, e6, e4});
+        addExpectedCycle(new LockEdge[] {e3, e8, e4});
+        addExpectedCycle(new LockEdge[] {e5, e7, e8});
+        addExpectedCycle(new LockEdge[] {e2, e7, e8, e4});
         assertExpectedCycles();
     }
 
@@ -246,57 +224,57 @@ public final class TestCycleDetector {
     public void testComplexCycles2() {
         int a = 6;
         int b = 3;
-        LockTransition e1 = addTransition(2, b);
-        LockTransition e2 = addTransition(b, 5);
-        LockTransition e3 = addTransition(5, 7);
-        LockTransition e4 = addTransition(7, 2);
-        LockTransition e5 = addTransition(2, a);
-        LockTransition e6 = addTransition(a, 5);
+        LockEdge e1 = addEdge(2, b);
+        LockEdge e2 = addEdge(b, 5);
+        LockEdge e3 = addEdge(5, 7);
+        LockEdge e4 = addEdge(7, 2);
+        LockEdge e5 = addEdge(2, a);
+        LockEdge e6 = addEdge(a, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e5, e6, e3, e4 });
-        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4 });
+        addExpectedCycle(new LockEdge[] {e5, e6, e3, e4 });
+        addExpectedCycle(new LockEdge[] {e1, e2, e3, e4 });
         assertExpectedCycles();
     }
 
 
     @Test
     public void testTwoSeparateCycles() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 1);
-        LockTransition e3 = addTransition(3, 4);
-        LockTransition e4 = addTransition(4, 3);
-        addTransition(4, 5);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 1);
+        LockEdge e3 = addEdge(3, 4);
+        LockEdge e4 = addEdge(4, 3);
+        addEdge(4, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e2});
-        addExpectedCycle(new LockTransition[] {e3, e4});
+        addExpectedCycle(new LockEdge[] {e1, e2});
+        addExpectedCycle(new LockEdge[] {e3, e4});
         assertExpectedCycles();
     }
 
     @Test
     public void testTwoConnectedCycles() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(2, 1);
-        LockTransition e3 = addTransition(2, 3);
-        LockTransition e4 = addTransition(3, 2);
-        addTransition(2, 4);
-        addTransition(3, 4);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(2, 1);
+        LockEdge e3 = addEdge(2, 3);
+        LockEdge e4 = addEdge(3, 2);
+        addEdge(2, 4);
+        addEdge(3, 4);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e2});
-        addExpectedCycle(new LockTransition[] {e3, e4});
+        addExpectedCycle(new LockEdge[] {e1, e2});
+        addExpectedCycle(new LockEdge[] {e3, e4});
         assertExpectedCycles();
     }
 
     @Test
     public void testDuplicatedEdges() {
-        LockTransition e1 = addTransition(1, 2);
-        LockTransition e2 = addTransition(1, 2, 10);
-        LockTransition e3 = addTransition(2, 1);
-        addTransition(3, 4);
-        addTransition(4, 5);
-        addTransition(4, 5, 10);
+        LockEdge e1 = addEdge(1, 2);
+        LockEdge e2 = addEdge(1, 2, 10);
+        LockEdge e3 = addEdge(2, 1);
+        addEdge(3, 4);
+        addEdge(4, 5);
+        addEdge(4, 5, 10);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockTransition[] {e1, e3});
-        addExpectedCycle(new LockTransition[] {e2, e3});
+        addExpectedCycle(new LockEdge[] {e1, e3});
+        addExpectedCycle(new LockEdge[] {e2, e3});
         assertExpectedCycles();
     }
 }

--- a/test/com/enea/jcarder/analyzer/TestCycleDetector.java
+++ b/test/com/enea/jcarder/analyzer/TestCycleDetector.java
@@ -16,19 +16,12 @@
 
 package com.enea.jcarder.analyzer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedList;
+import java.util.*;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.enea.jcarder.analyzer.Cycle;
-import com.enea.jcarder.analyzer.CycleDetector;
-import com.enea.jcarder.analyzer.LockEdge;
-import com.enea.jcarder.analyzer.LockGraphBuilder;
-import com.enea.jcarder.analyzer.LockNode;
 import com.enea.jcarder.util.logging.Logger;
 
 /*
@@ -40,250 +33,270 @@ public final class TestCycleDetector {
     LockGraphBuilder mBuilder;
     CycleDetector mCycleDetector;
     LinkedList<LockNode> mNodes;
-    HashSet<Cycle> mExpectedCycles;
+    Set<Set<LockTransition>> mExpectedCycles;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mBuilder = new LockGraphBuilder(new Logger(null), null);
         mCycleDetector = new CycleDetector(new Logger(null));
-        mNodes = new LinkedList<LockNode>();
-        mExpectedCycles = new HashSet<Cycle>();
+        mNodes = new LinkedList<>();
+        mExpectedCycles = new HashSet<>();
     }
 
-    private LockEdge addEdge(int from, int to) {
-        return addEdge(from, to, -1);
+    private LockTransition addTransition(int from, int to) {
+        return addTransition(from, to, -1);
     }
 
-    private LockEdge addEdge(int from, int to, int threadId) {
+    private LockTransition addTransition(int from, int to, int threadId) {
         final LockNode sourceLock = mBuilder.getLockNode(from);
         final LockNode targetLock = mBuilder.getLockNode(to);
-        final LockEdge edge = new LockEdge(sourceLock,
-                                           targetLock,
-                                           threadId,
-                                           -1,
-                                           -1);
-        sourceLock.addOutgoingEdge(edge);
+        final LockEdge edge = new LockEdge(sourceLock, targetLock);
+        LockTransition transition = new LockTransition(threadId, -1, -1);
+        sourceLock.addOutgoingEdge(edge)
+                .addTransition(transition);
         if (!mNodes.contains(sourceLock)) {
             mNodes.add(sourceLock);
         }
         if (!mNodes.contains(sourceLock)) {
             mNodes.add(sourceLock);
         }
-        return edge;
+        return transition;
     }
 
-    private void addExpectedCycle(LockEdge[] edges) {
-        Cycle cycle = new Cycle(Arrays.asList(edges));
-        mExpectedCycles.add(cycle);
+    private void addExpectedCycle(LockTransition[] transitions) {
+        Set<LockTransition> set = Collections.newSetFromMap(new IdentityHashMap<>());
+        set.addAll(Arrays.asList(transitions));
+        mExpectedCycles.add(set);
     }
 
     private void assertExpectedCycles() {
-        Assert.assertEquals(mExpectedCycles, mCycleDetector.getCycles());
+        Assert.assertEquals(mExpectedCycles, getTransitionCycles(mCycleDetector.getCycles()));
+    }
+
+    private Set<Set> getTransitionCycles(HashSet<Cycle> cycles) {
+        Set<Set> transitionCycles = new HashSet<>();
+        for (Cycle cycle : cycles) {
+            addAllTransitionCycles(new ArrayList<>(cycle.getEdges()), transitionCycles, new LockTransition[cycle.getEdges().size()], 0);
+        }
+        return transitionCycles;
+    }
+
+    private void addAllTransitionCycles(List<LockEdge> edges, Collection<Set> cycles, LockTransition[] transitionsContainer, int start) {
+        if (start == edges.size()) {
+            Set<LockTransition> set = Collections.newSetFromMap(new IdentityHashMap<>());
+            set.addAll(Arrays.asList(transitionsContainer));
+            cycles.add(set);
+            return;
+        }
+        for (LockTransition transition : edges.get(start).getTransitions()) {
+            transitionsContainer[start] = transition;
+            addAllTransitionCycles(edges, cycles, transitionsContainer, start + 1);
+        }
     }
 
     @Test
-    public void testNoCycle() throws Exception {
-        addEdge(1, 2);
-        addEdge(2, 3);
-        addEdge(1, 3);
-        addEdge(3, 4);
+    public void testNoCycle() {
+        addTransition(1, 2);
+        addTransition(2, 3);
+        addTransition(1, 3);
+        addTransition(3, 4);
         mCycleDetector.analyzeLockNodes(mNodes);
         assertExpectedCycles();
     }
 
     @Test
-    public void testSmallCycle() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 1);
+    public void testSmallCycle() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e1, e2});
         assertExpectedCycles();
     }
 
     @Test
-    public void testCycle() throws Exception {
-        addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 3);
-        LockEdge e3 = addEdge(3, 4);
-        LockEdge e4 = addEdge(4, 2);
-        addEdge(4, 5);
+    public void testCycle() {
+        addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 3);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e4 = addTransition(4, 2);
+        addTransition(4, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e2, e3, e4});
+        addExpectedCycle(new LockTransition[] {e2, e3, e4});
         assertExpectedCycles();
     }
 
     @Test
-    public void testCyclesWithTwoPaths() throws Exception {
-        addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 3);
-        LockEdge e3 = addEdge(3, 4);
-        LockEdge e4 = addEdge(2, 4);
-        LockEdge e5 = addEdge(4, 2);
+    public void testCyclesWithTwoPaths() {
+        addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 3);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e4 = addTransition(2, 4);
+        LockTransition e5 = addTransition(4, 2);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e2, e3, e5});
-        addExpectedCycle(new LockEdge[] {e4, e5});
+        addExpectedCycle(new LockTransition[] {e2, e3, e5});
+        addExpectedCycle(new LockTransition[] {e4, e5});
         assertExpectedCycles();
     }
 
     @Test
-    public void testCyclesWithTwoTimesTwoPathsLarge() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 3);
-        LockEdge e3 = addEdge(3, 4);
-        LockEdge e3b = addEdge(3, 4, 2);
-        LockEdge e4 = addEdge(4, 5);
-        LockEdge e5 = addEdge(5, 6);
-        LockEdge e6 = addEdge(6, 1);
-        LockEdge e6b = addEdge(6, 1, 2);
+    public void testCyclesWithTwoTimesTwoPathsLarge() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 3);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e3b = addTransition(3, 4, 2);
+        LockTransition e4 = addTransition(4, 5);
+        LockTransition e5 = addTransition(5, 6);
+        LockTransition e6 = addTransition(6, 1);
+        LockTransition e6b = addTransition(6, 1, 2);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e2, e3, e4, e5, e6});
-        addExpectedCycle(new LockEdge[] {e1, e2, e3b, e4, e5, e6});
-        addExpectedCycle(new LockEdge[] {e1, e2, e3b, e4, e5, e6b});
-        addExpectedCycle(new LockEdge[] {e1, e2, e3, e4, e5, e6b});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4, e5, e6});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3b, e4, e5, e6});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3b, e4, e5, e6b});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4, e5, e6b});
         assertExpectedCycles();
     }
 
     @Test
-    public void testCyclesWithTwoTimesTwoPathsSmall() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 1);
-        LockEdge e1b = addEdge(1, 2, 2);
-        LockEdge e2b = addEdge(2, 1, 2);
+    public void testCyclesWithTwoTimesTwoPathsSmall() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        LockTransition e1b = addTransition(1, 2, 2);
+        LockTransition e2b = addTransition(2, 1, 2);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e2});
-        addExpectedCycle(new LockEdge[] {e1b, e2});
-        addExpectedCycle(new LockEdge[] {e1, e2b});
-        addExpectedCycle(new LockEdge[] {e1b, e2b});
-        assertExpectedCycles();
-    }
-
-
-    @Test
-    public void testCyclesWithTwoAlternateWays() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(1, 3);
-        LockEdge e3 = addEdge(2, 4);
-        LockEdge e4 = addEdge(3, 4);
-        LockEdge e5 = addEdge(4, 5);
-        LockEdge e6 = addEdge(4, 6);
-        LockEdge e7 = addEdge(5, 1);
-        LockEdge e8 = addEdge(6, 1);
-
-        mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e3, e5, e7});
-        addExpectedCycle(new LockEdge[] {e1, e3, e6, e8});
-        addExpectedCycle(new LockEdge[] {e2, e4, e5, e7});
-        addExpectedCycle(new LockEdge[] {e2, e4, e6, e8});
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e1b, e2});
+        addExpectedCycle(new LockTransition[] {e1, e2b});
+        addExpectedCycle(new LockTransition[] {e1b, e2b});
         assertExpectedCycles();
     }
 
 
     @Test
-    public void testComplexCycles() throws Exception {
+    public void testCyclesWithTwoAlternateWays() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(1, 3);
+        LockTransition e3 = addTransition(2, 4);
+        LockTransition e4 = addTransition(3, 4);
+        LockTransition e5 = addTransition(4, 5);
+        LockTransition e6 = addTransition(4, 6);
+        LockTransition e7 = addTransition(5, 1);
+        LockTransition e8 = addTransition(6, 1);
+
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e3, e5, e7});
+        addExpectedCycle(new LockTransition[] {e1, e3, e6, e8});
+        addExpectedCycle(new LockTransition[] {e2, e4, e5, e7});
+        addExpectedCycle(new LockTransition[] {e2, e4, e6, e8});
+        assertExpectedCycles();
+    }
+
+
+    @Test
+    public void testComplexCycles() {
         int a = 6;
         int b = 3;
-        addEdge(1, 2);
-        LockEdge e2 = addEdge(2, b);
-        LockEdge e3 = addEdge(b, 4);
-        LockEdge e4 = addEdge(4, b);
-        LockEdge e5 = addEdge(b, 5);
-        LockEdge e6 = addEdge(5, 7);
-        LockEdge e7 = addEdge(7, 2);
-        LockEdge e8 = addEdge(2, a);
-        LockEdge e9 = addEdge(a, 5);
-        LockEdge e10 = addEdge(5, 8);
-        LockEdge e11 = addEdge(8, 9);
-        LockEdge e12 = addEdge(9, 5);
+        addTransition(1, 2);
+        LockTransition e2 = addTransition(2, b);
+        LockTransition e3 = addTransition(b, 4);
+        LockTransition e4 = addTransition(4, b);
+        LockTransition e5 = addTransition(b, 5);
+        LockTransition e6 = addTransition(5, 7);
+        LockTransition e7 = addTransition(7, 2);
+        LockTransition e8 = addTransition(2, a);
+        LockTransition e9 = addTransition(a, 5);
+        LockTransition e10 = addTransition(5, 8);
+        LockTransition e11 = addTransition(8, 9);
+        LockTransition e12 = addTransition(9, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e3, e4});
-        addExpectedCycle(new LockEdge[] {e10, e11, e12});
-        addExpectedCycle(new LockEdge[] {e8, e9, e6, e7});
-        addExpectedCycle(new LockEdge[] {e2, e5, e6, e7});
+        addExpectedCycle(new LockTransition[] {e3, e4});
+        addExpectedCycle(new LockTransition[] {e10, e11, e12});
+        addExpectedCycle(new LockTransition[] {e8, e9, e6, e7});
+        addExpectedCycle(new LockTransition[] {e2, e5, e6, e7});
         assertExpectedCycles();
     }
 
 
     @Test
-    public void testLotsOfCycles() throws Exception {
+    public void testLotsOfCycles() {
         int a = 1;
         int b = 2;
         int c = 3;
         int d = 4;
 
-        LockEdge e1 = addEdge(a, b);
-        LockEdge e2 = addEdge(a, c);
-        LockEdge e3 = addEdge(a, d);
-        LockEdge e4 = addEdge(b, a);
-        LockEdge e5 = addEdge(b, c);
-        LockEdge e6 = addEdge(c, b);
-        LockEdge e7 = addEdge(c, d);
-        LockEdge e8 = addEdge(d, b);
+        LockTransition e1 = addTransition(a, b);
+        LockTransition e2 = addTransition(a, c);
+        LockTransition e3 = addTransition(a, d);
+        LockTransition e4 = addTransition(b, a);
+        LockTransition e5 = addTransition(b, c);
+        LockTransition e6 = addTransition(c, b);
+        LockTransition e7 = addTransition(c, d);
+        LockTransition e8 = addTransition(d, b);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e4});
-        addExpectedCycle(new LockEdge[] {e5, e6});
-        addExpectedCycle(new LockEdge[] {e2, e6, e4});
-        addExpectedCycle(new LockEdge[] {e3, e8, e4});
-        addExpectedCycle(new LockEdge[] {e5, e7, e8});
-        addExpectedCycle(new LockEdge[] {e2, e7, e8, e4});
+        addExpectedCycle(new LockTransition[] {e1, e4});
+        addExpectedCycle(new LockTransition[] {e5, e6});
+        addExpectedCycle(new LockTransition[] {e2, e6, e4});
+        addExpectedCycle(new LockTransition[] {e3, e8, e4});
+        addExpectedCycle(new LockTransition[] {e5, e7, e8});
+        addExpectedCycle(new LockTransition[] {e2, e7, e8, e4});
         assertExpectedCycles();
     }
 
 
     @Test
-    public void testComplexCycles2() throws Exception {
+    public void testComplexCycles2() {
         int a = 6;
         int b = 3;
-        LockEdge e1 = addEdge(2, b);
-        LockEdge e2 = addEdge(b, 5);
-        LockEdge e3 = addEdge(5, 7);
-        LockEdge e4 = addEdge(7, 2);
-        LockEdge e5 = addEdge(2, a);
-        LockEdge e6 = addEdge(a, 5);
+        LockTransition e1 = addTransition(2, b);
+        LockTransition e2 = addTransition(b, 5);
+        LockTransition e3 = addTransition(5, 7);
+        LockTransition e4 = addTransition(7, 2);
+        LockTransition e5 = addTransition(2, a);
+        LockTransition e6 = addTransition(a, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e5, e6, e3, e4 });
-        addExpectedCycle(new LockEdge[] {e1, e2, e3, e4 });
+        addExpectedCycle(new LockTransition[] {e5, e6, e3, e4 });
+        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4 });
         assertExpectedCycles();
     }
 
 
     @Test
-    public void testTwoSeparateCycles() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 1);
-        LockEdge e3 = addEdge(3, 4);
-        LockEdge e4 = addEdge(4, 3);
-        addEdge(4, 5);
+    public void testTwoSeparateCycles() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e4 = addTransition(4, 3);
+        addTransition(4, 5);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e2});
-        addExpectedCycle(new LockEdge[] {e3, e4});
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e3, e4});
         assertExpectedCycles();
     }
 
     @Test
-    public void testTwoConnectedCycles() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(2, 1);
-        LockEdge e3 = addEdge(2, 3);
-        LockEdge e4 = addEdge(3, 2);
-        addEdge(2, 4);
-        addEdge(3, 4);
+    public void testTwoConnectedCycles() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        LockTransition e3 = addTransition(2, 3);
+        LockTransition e4 = addTransition(3, 2);
+        addTransition(2, 4);
+        addTransition(3, 4);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e2});
-        addExpectedCycle(new LockEdge[] {e3, e4});
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e3, e4});
         assertExpectedCycles();
     }
 
     @Test
-    public void testDuplicatedEdges() throws Exception {
-        LockEdge e1 = addEdge(1, 2);
-        LockEdge e2 = addEdge(1, 2, 10);
-        LockEdge e3 = addEdge(2, 1);
-        addEdge(3, 4);
-        addEdge(4, 5);
-        addEdge(4, 5, 10);
+    public void testDuplicatedEdges() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(1, 2, 10);
+        LockTransition e3 = addTransition(2, 1);
+        addTransition(3, 4);
+        addTransition(4, 5);
+        addTransition(4, 5, 10);
         mCycleDetector.analyzeLockNodes(mNodes);
-        addExpectedCycle(new LockEdge[] {e1, e3});
-        addExpectedCycle(new LockEdge[] {e2, e3});
+        addExpectedCycle(new LockTransition[] {e1, e3});
+        addExpectedCycle(new LockTransition[] {e2, e3});
         assertExpectedCycles();
     }
 }

--- a/test/com/enea/jcarder/analyzer/TestFastCycleDetector.java
+++ b/test/com/enea/jcarder/analyzer/TestFastCycleDetector.java
@@ -1,0 +1,302 @@
+/*
+ * JCarder -- cards Java programs to keep threads disentangled
+ *
+ * Copyright (C) 2006-2007 Enea AB
+ * Copyright (C) 2007 Ulrik Svensson
+ * Copyright (C) 2007 Joel Rosdahl
+ *
+ * This program is made available under the GNU GPL version 2, with a special
+ * exception for linking with JUnit. See the accompanying file LICENSE.txt for
+ * details.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.enea.jcarder.analyzer;
+
+import java.util.*;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.enea.jcarder.util.logging.Logger;
+
+/*
+ * The purpose of this junit class is to test the class CycleDetector with "fast" mode
+ *
+ * TODO Some important methods in CycleDetector are not tested yet.
+ */
+public final class TestFastCycleDetector {
+    private LockGraphBuilder mBuilder;
+    private CycleDetector mCycleDetector;
+    private LinkedList<LockNode> mNodes;
+    private Set<Set<LockTransition>> mExpectedCycles;
+
+    @Before
+    public void setUp() {
+        mBuilder = new LockGraphBuilder(new Logger(null), true, null);
+        mCycleDetector = new CycleDetector(new Logger(null), true);
+        mNodes = new LinkedList<>();
+        mExpectedCycles = new HashSet<>();
+    }
+
+    private LockTransition addTransition(int from, int to) {
+        return addTransition(from, to, -1);
+    }
+
+    private LockTransition addTransition(int from, int to, int threadId) {
+        final LockNode sourceLock = mBuilder.getLockNode(from);
+        final LockNode targetLock = mBuilder.getLockNode(to);
+        final LockEdge edge = new LockMultiEdge(sourceLock, targetLock);
+        LockTransition transition = new LockTransition(threadId, -1, -1);
+        ((LockMultiEdge)sourceLock.addOutgoingEdge(edge))
+                .addTransition(transition);
+        if (!mNodes.contains(sourceLock)) {
+            mNodes.add(sourceLock);
+        }
+        if (!mNodes.contains(sourceLock)) {
+            mNodes.add(sourceLock);
+        }
+        return transition;
+    }
+
+    private void addExpectedCycle(LockTransition[] transitions) {
+        Set<LockTransition> set = Collections.newSetFromMap(new IdentityHashMap<>());
+        set.addAll(Arrays.asList(transitions));
+        mExpectedCycles.add(set);
+    }
+
+    private void assertExpectedCycles() {
+        Assert.assertEquals(mExpectedCycles, getTransitionCycles(mCycleDetector.getCycles()));
+    }
+
+    private Set<Set> getTransitionCycles(HashSet<Cycle> cycles) {
+        Set<Set> transitionCycles = new HashSet<>();
+        for (Cycle cycle : cycles) {
+            addAllTransitionCycles(new ArrayList<>(cycle.getEdges()), transitionCycles, new LockTransition[cycle.getEdges().size()], 0);
+        }
+        return transitionCycles;
+    }
+
+    private void addAllTransitionCycles(List<LockEdge> edges, Collection<Set> cycles, LockTransition[] transitionsContainer, int start) {
+        if (start == edges.size()) {
+            Set<LockTransition> set = Collections.newSetFromMap(new IdentityHashMap<>());
+            set.addAll(Arrays.asList(transitionsContainer));
+            cycles.add(set);
+            return;
+        }
+        for (LockTransition transition : edges.get(start).getTransitions()) {
+            transitionsContainer[start] = transition;
+            addAllTransitionCycles(edges, cycles, transitionsContainer, start + 1);
+        }
+    }
+
+    @Test
+    public void testNoCycle() {
+        addTransition(1, 2);
+        addTransition(2, 3);
+        addTransition(1, 3);
+        addTransition(3, 4);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testSmallCycle() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testCycle() {
+        addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 3);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e4 = addTransition(4, 2);
+        addTransition(4, 5);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e2, e3, e4});
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testCyclesWithTwoPaths() {
+        addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 3);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e4 = addTransition(2, 4);
+        LockTransition e5 = addTransition(4, 2);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e2, e3, e5});
+        addExpectedCycle(new LockTransition[] {e4, e5});
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testCyclesWithTwoTimesTwoPathsLarge() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 3);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e3b = addTransition(3, 4, 2);
+        LockTransition e4 = addTransition(4, 5);
+        LockTransition e5 = addTransition(5, 6);
+        LockTransition e6 = addTransition(6, 1);
+        LockTransition e6b = addTransition(6, 1, 2);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4, e5, e6});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3b, e4, e5, e6});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3b, e4, e5, e6b});
+        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4, e5, e6b});
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testCyclesWithTwoTimesTwoPathsSmall() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        LockTransition e1b = addTransition(1, 2, 2);
+        LockTransition e2b = addTransition(2, 1, 2);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e1b, e2});
+        addExpectedCycle(new LockTransition[] {e1, e2b});
+        addExpectedCycle(new LockTransition[] {e1b, e2b});
+        assertExpectedCycles();
+    }
+
+
+    @Test
+    public void testCyclesWithTwoAlternateWays() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(1, 3);
+        LockTransition e3 = addTransition(2, 4);
+        LockTransition e4 = addTransition(3, 4);
+        LockTransition e5 = addTransition(4, 5);
+        LockTransition e6 = addTransition(4, 6);
+        LockTransition e7 = addTransition(5, 1);
+        LockTransition e8 = addTransition(6, 1);
+
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e3, e5, e7});
+        addExpectedCycle(new LockTransition[] {e1, e3, e6, e8});
+        addExpectedCycle(new LockTransition[] {e2, e4, e5, e7});
+        addExpectedCycle(new LockTransition[] {e2, e4, e6, e8});
+        assertExpectedCycles();
+    }
+
+
+    @Test
+    public void testComplexCycles() {
+        int a = 6;
+        int b = 3;
+        addTransition(1, 2);
+        LockTransition e2 = addTransition(2, b);
+        LockTransition e3 = addTransition(b, 4);
+        LockTransition e4 = addTransition(4, b);
+        LockTransition e5 = addTransition(b, 5);
+        LockTransition e6 = addTransition(5, 7);
+        LockTransition e7 = addTransition(7, 2);
+        LockTransition e8 = addTransition(2, a);
+        LockTransition e9 = addTransition(a, 5);
+        LockTransition e10 = addTransition(5, 8);
+        LockTransition e11 = addTransition(8, 9);
+        LockTransition e12 = addTransition(9, 5);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e3, e4});
+        addExpectedCycle(new LockTransition[] {e10, e11, e12});
+        addExpectedCycle(new LockTransition[] {e8, e9, e6, e7});
+        addExpectedCycle(new LockTransition[] {e2, e5, e6, e7});
+        assertExpectedCycles();
+    }
+
+
+    @Test
+    public void testLotsOfCycles() {
+        int a = 1;
+        int b = 2;
+        int c = 3;
+        int d = 4;
+
+        LockTransition e1 = addTransition(a, b);
+        LockTransition e2 = addTransition(a, c);
+        LockTransition e3 = addTransition(a, d);
+        LockTransition e4 = addTransition(b, a);
+        LockTransition e5 = addTransition(b, c);
+        LockTransition e6 = addTransition(c, b);
+        LockTransition e7 = addTransition(c, d);
+        LockTransition e8 = addTransition(d, b);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e4});
+        addExpectedCycle(new LockTransition[] {e5, e6});
+        addExpectedCycle(new LockTransition[] {e2, e6, e4});
+        addExpectedCycle(new LockTransition[] {e3, e8, e4});
+        addExpectedCycle(new LockTransition[] {e5, e7, e8});
+        addExpectedCycle(new LockTransition[] {e2, e7, e8, e4});
+        assertExpectedCycles();
+    }
+
+
+    @Test
+    public void testComplexCycles2() {
+        int a = 6;
+        int b = 3;
+        LockTransition e1 = addTransition(2, b);
+        LockTransition e2 = addTransition(b, 5);
+        LockTransition e3 = addTransition(5, 7);
+        LockTransition e4 = addTransition(7, 2);
+        LockTransition e5 = addTransition(2, a);
+        LockTransition e6 = addTransition(a, 5);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e5, e6, e3, e4 });
+        addExpectedCycle(new LockTransition[] {e1, e2, e3, e4 });
+        assertExpectedCycles();
+    }
+
+
+    @Test
+    public void testTwoSeparateCycles() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        LockTransition e3 = addTransition(3, 4);
+        LockTransition e4 = addTransition(4, 3);
+        addTransition(4, 5);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e3, e4});
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testTwoConnectedCycles() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(2, 1);
+        LockTransition e3 = addTransition(2, 3);
+        LockTransition e4 = addTransition(3, 2);
+        addTransition(2, 4);
+        addTransition(3, 4);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e2});
+        addExpectedCycle(new LockTransition[] {e3, e4});
+        assertExpectedCycles();
+    }
+
+    @Test
+    public void testDuplicatedEdges() {
+        LockTransition e1 = addTransition(1, 2);
+        LockTransition e2 = addTransition(1, 2, 10);
+        LockTransition e3 = addTransition(2, 1);
+        addTransition(3, 4);
+        addTransition(4, 5);
+        addTransition(4, 5, 10);
+        mCycleDetector.analyzeLockNodes(mNodes);
+        addExpectedCycle(new LockTransition[] {e1, e3});
+        addExpectedCycle(new LockTransition[] {e2, e3});
+        assertExpectedCycles();
+    }
+}

--- a/test/com/enea/jcarder/analyzer/TestLockNode.java
+++ b/test/com/enea/jcarder/analyzer/TestLockNode.java
@@ -29,7 +29,7 @@ public final class TestLockNode {
     private LockNode node3;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         node1 = new LockNode(1);
         node2 = new LockNode(2);
         node3 = new LockNode(3);
@@ -37,30 +37,30 @@ public final class TestLockNode {
 
     @Test
     public void testAddOutgoingEdge() {
-        addOutgoingEdge(node1, node1, node2, 5, 5, 5);
-        addOutgoingEdge(node1, node1, node2, 5, 5, 5);
-        addOutgoingEdge(node1, node1, node2, 5, 5, 5);
-        addOutgoingEdge(node1, node1, node3, 5, 5, 5);
-        addOutgoingEdge(node1, node1, node2, 6, 5, 5);
-        addOutgoingEdge(node1, node1, node2, 5, 6, 5);
-        addOutgoingEdge(node1, node1, node2, 5, 5, 6);
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(5, 5, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(5, 5, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(5, 5, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node3, new LockTransition(5, 5, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(6, 5, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(5, 6, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(5, 5, 6)));
         assertEquals(5L, node1.numberOfUniqueTransitions());
         assertEquals(2L, node1.numberOfDuplicatedTransitions());
     }
 
     @Test
     public void testPopulateContextIdTranslationMap() {
-        addOutgoingEdge(node1, node1, node2, 1, 2, 3);
-        addOutgoingEdge(node1, node1, node2, 1, 4, 5);
-        addOutgoingEdge(node1, node1, node2, 1, 4, 6);
-        addOutgoingEdge(node1, node1, node2, 1, 4, 6);
-        addOutgoingEdge(node1, node1, node3, 1, 4, 6);
-        addOutgoingEdge(node1, node1, node3, 1, 7, 8);
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 2, 3)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 4, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 4, 6)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 4, 6)));
+        node1.addOutgoingEdge(new LockEdge(node1, node3, new LockTransition(1, 4, 6)));
+        node1.addOutgoingEdge(new LockEdge(node1, node3, new LockTransition(1, 7, 8)));
         final HashMap<Integer, Integer> translationMap =
-            new HashMap<Integer, Integer>();
+                new HashMap<>();
         node1.populateContextIdTranslationMap(translationMap);
         final HashMap<Integer, Integer> expectedTranslationMap =
-            new HashMap<Integer, Integer>();
+                new HashMap<>();
         expectedTranslationMap.put(2, 2);
         expectedTranslationMap.put(3, 3);
         expectedTranslationMap.put(4, 4);
@@ -73,16 +73,16 @@ public final class TestLockNode {
 
     @Test
     public void testUpdateContextIdsInEdges() {
-        addOutgoingEdge(node1, node1, node2, 1, 2, 3);
-        addOutgoingEdge(node1, node1, node2, 1, 2, 3);
-        addOutgoingEdge(node1, node1, node2, 99, 2, 3);
-        addOutgoingEdge(node1, node1, node2, 1, 4, 5);
-        addOutgoingEdge(node1, node1, node2, 1, 6, 7);
-        addOutgoingEdge(node1, node1, node3, 1, 2, 3);
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 2, 3)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 2, 3)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(99, 2, 3)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 4, 5)));
+        node1.addOutgoingEdge(new LockEdge(node1, node2, new LockTransition(1, 6, 7)));
+        node1.addOutgoingEdge(new LockEdge(node1, node3, new LockTransition(1, 2, 3)));
         assertEquals(1L, node1.numberOfDuplicatedTransitions());
         assertEquals(5L, node1.numberOfUniqueTransitions());
         final HashMap<Integer, Integer> translationMap =
-            new HashMap<Integer, Integer>();
+                new HashMap<>();
         translationMap.put(2, 12);
         translationMap.put(3, 13);
         translationMap.put(4, 12);
@@ -92,31 +92,9 @@ public final class TestLockNode {
         assertEquals(2L, node1.numberOfDuplicatedTransitions());
         assertEquals(4L, node1.numberOfUniqueTransitions());
         final Collection<LockEdge> edges = node1.getOutgoingEdges();
-        assertTrue(contains(edges, createEdge(node1, node2, 1, 12, 13)));
-        assertTrue(contains(edges, createEdge(node1, node2, 99, 12, 13)));
-        assertTrue(contains(edges, createEdge(node1, node2, 1, 6, 7)));
-        assertTrue(contains(edges, createEdge(node1, node3, 1, 12, 13)));
-    }
-
-    private static void addOutgoingEdge(LockNode source, LockNode node1, LockNode node2, int threadId, int sourceContextId, int targetContextId) {
-        source.addOutgoingEdge(new LockEdge(node1, node2))
-                .addTransition(new LockTransition(threadId, sourceContextId, targetContextId));
-    }
-    
-    private static LockEdge createEdge(LockNode node1, LockNode node2, int threadId, int sourceContextId, int targetContextId) {
-        LockEdge lockEdge = new LockEdge(node1, node2);
-        lockEdge.addTransition(new LockTransition(threadId, sourceContextId, targetContextId));
-        return lockEdge;
-    }
-
-    private boolean contains(Collection<LockEdge> edges, LockEdge edge) {
-        for (LockEdge lockEdge : edges) {
-            if (lockEdge.equals(edge)) {
-                if (lockEdge.getTransitions().containsAll(edge.getTransitions())) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        assertTrue(edges.contains(new LockEdge(node1, node2, new LockTransition(1, 12, 13))));
+        assertTrue(edges.contains(new LockEdge(node1, node2, new LockTransition(99, 12, 13))));
+        assertTrue(edges.contains(new LockEdge(node1, node2, new LockTransition(1, 6, 7))));
+        assertTrue(edges.contains(new LockEdge(node1, node3, new LockTransition(1, 12, 13))));
     }
 }

--- a/test/com/enea/jcarder/analyzer/TestLockNode.java
+++ b/test/com/enea/jcarder/analyzer/TestLockNode.java
@@ -23,9 +23,6 @@ import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.enea.jcarder.analyzer.LockEdge;
-import com.enea.jcarder.analyzer.LockNode;
-
 public final class TestLockNode {
     private LockNode node1;
     private LockNode node2;
@@ -40,25 +37,25 @@ public final class TestLockNode {
 
     @Test
     public void testAddOutgoingEdge() {
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 5, 5, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 5, 5, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 5, 5, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node3, 5, 5, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 6, 5, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 5, 6, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 5, 5, 6));
-        assertEquals(5L, node1.numberOfUniqueEdges());
-        assertEquals(2L, node1.numberOfDuplicatedEdges());
+        addOutgoingEdge(node1, node1, node2, 5, 5, 5);
+        addOutgoingEdge(node1, node1, node2, 5, 5, 5);
+        addOutgoingEdge(node1, node1, node2, 5, 5, 5);
+        addOutgoingEdge(node1, node1, node3, 5, 5, 5);
+        addOutgoingEdge(node1, node1, node2, 6, 5, 5);
+        addOutgoingEdge(node1, node1, node2, 5, 6, 5);
+        addOutgoingEdge(node1, node1, node2, 5, 5, 6);
+        assertEquals(5L, node1.numberOfUniqueTransitions());
+        assertEquals(2L, node1.numberOfDuplicatedTransitions());
     }
 
     @Test
     public void testPopulateContextIdTranslationMap() {
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 2, 3));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 4, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 4, 6));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 4, 6));
-        node1.addOutgoingEdge(new LockEdge(node1, node3, 1, 4, 6));
-        node1.addOutgoingEdge(new LockEdge(node1, node3, 1, 7, 8));
+        addOutgoingEdge(node1, node1, node2, 1, 2, 3);
+        addOutgoingEdge(node1, node1, node2, 1, 4, 5);
+        addOutgoingEdge(node1, node1, node2, 1, 4, 6);
+        addOutgoingEdge(node1, node1, node2, 1, 4, 6);
+        addOutgoingEdge(node1, node1, node3, 1, 4, 6);
+        addOutgoingEdge(node1, node1, node3, 1, 7, 8);
         final HashMap<Integer, Integer> translationMap =
             new HashMap<Integer, Integer>();
         node1.populateContextIdTranslationMap(translationMap);
@@ -76,14 +73,14 @@ public final class TestLockNode {
 
     @Test
     public void testUpdateContextIdsInEdges() {
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 2, 3));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 2, 3));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 99, 2, 3));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 4, 5));
-        node1.addOutgoingEdge(new LockEdge(node1, node2, 1, 6, 7));
-        node1.addOutgoingEdge(new LockEdge(node1, node3, 1, 2, 3));
-        assertEquals(1L, node1.numberOfDuplicatedEdges());
-        assertEquals(5L, node1.numberOfUniqueEdges());
+        addOutgoingEdge(node1, node1, node2, 1, 2, 3);
+        addOutgoingEdge(node1, node1, node2, 1, 2, 3);
+        addOutgoingEdge(node1, node1, node2, 99, 2, 3);
+        addOutgoingEdge(node1, node1, node2, 1, 4, 5);
+        addOutgoingEdge(node1, node1, node2, 1, 6, 7);
+        addOutgoingEdge(node1, node1, node3, 1, 2, 3);
+        assertEquals(1L, node1.numberOfDuplicatedTransitions());
+        assertEquals(5L, node1.numberOfUniqueTransitions());
         final HashMap<Integer, Integer> translationMap =
             new HashMap<Integer, Integer>();
         translationMap.put(2, 12);
@@ -92,12 +89,34 @@ public final class TestLockNode {
         translationMap.put(5, 13);
         translationMap.put(6, 6);
         node1.translateContextIds(translationMap);
-        assertEquals(2L, node1.numberOfDuplicatedEdges());
-        assertEquals(4L, node1.numberOfUniqueEdges());
+        assertEquals(2L, node1.numberOfDuplicatedTransitions());
+        assertEquals(4L, node1.numberOfUniqueTransitions());
         final Collection<LockEdge> edges = node1.getOutgoingEdges();
-        assertTrue(edges.contains(new LockEdge(node1, node2, 1, 12, 13)));
-        assertTrue(edges.contains(new LockEdge(node1, node2, 99, 12, 13)));
-        assertTrue(edges.contains(new LockEdge(node1, node2, 1, 6, 7)));
-        assertTrue(edges.contains(new LockEdge(node1, node3, 1, 12, 13)));
+        assertTrue(contains(edges, createEdge(node1, node2, 1, 12, 13)));
+        assertTrue(contains(edges, createEdge(node1, node2, 99, 12, 13)));
+        assertTrue(contains(edges, createEdge(node1, node2, 1, 6, 7)));
+        assertTrue(contains(edges, createEdge(node1, node3, 1, 12, 13)));
+    }
+
+    private static void addOutgoingEdge(LockNode source, LockNode node1, LockNode node2, int threadId, int sourceContextId, int targetContextId) {
+        source.addOutgoingEdge(new LockEdge(node1, node2))
+                .addTransition(new LockTransition(threadId, sourceContextId, targetContextId));
+    }
+    
+    private static LockEdge createEdge(LockNode node1, LockNode node2, int threadId, int sourceContextId, int targetContextId) {
+        LockEdge lockEdge = new LockEdge(node1, node2);
+        lockEdge.addTransition(new LockTransition(threadId, sourceContextId, targetContextId));
+        return lockEdge;
+    }
+
+    private boolean contains(Collection<LockEdge> edges, LockEdge edge) {
+        for (LockEdge lockEdge : edges) {
+            if (lockEdge.equals(edge)) {
+                if (lockEdge.getTransitions().containsAll(edge.getTransitions())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
it's needed to replace plenty of edges between two nodes with one edge having multiple transition entities
it allows to dramatically speed up cycle detection step and improve memory consumed by found cycles
but on the other hand, some cycles potentially cannot be skipped on the "remove single-threaded locks", "remove gated cycles"